### PR TITLE
Update quickstart.asciidoc

### DIFF
--- a/docs/quickstart.asciidoc
+++ b/docs/quickstart.asciidoc
@@ -98,6 +98,16 @@ spec:
     count: 1
     config:
       node.store.allow_mmap: false
+    podTemplate:
+      spec:
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 0
+        initContainers:
+        - name: elastic-internal-init-filesystem
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0      
 EOF
 ----
 


### PR DESCRIPTION
java.io.IOException: failed to obtain lock on /usr/share/elasticsearch/data/    ECK failing with above error on installation step because of permission issue , and thus updating permission on Elasticsearch init filesystem
